### PR TITLE
Changing the example to a full object example

### DIFF
--- a/AJAX Example.js
+++ b/AJAX Example.js
@@ -12,7 +12,8 @@ function onLoad() {
  
   function GetRelatedIncidentCount(response) { 
     var answer = response.responseXML.documentElement.getAttribute("answer"); 
-    alert('Related Incidents: ' + answer); 
+    var results = JSON.parse(answer);
+    alert('Related Incidents: ' + results.row_count); 
   } 
 } 
  
@@ -22,11 +23,16 @@ var ChangeManagementRelatedRecords = Class.create();
 ChangeManagementRelatedRecords.prototype = Object.extendsObject(AbstractAjaxProcessor, { 
     
 getIncidentCount: function() { 
+ 
  var changeID = this.getParameter('sysparm_change_id'); 
  var incident = new GlideRecord('incident'); 
  incident.addQuery('rfc', changeID); 
  incident.query(); 
- return incident.getRowCount() 
+ 
+ var results = {};
+ results.row_count = incident.getRowCount();
+ 
+ return JSON.stringify(results);
 }, 
   
    _privateFunction: function() { // this function is not client callable      


### PR DESCRIPTION
I prefer to keep my mind on doing it this way so that if I ever need to return more than one item, the script is ready for it.
In the script include, you just need to set new properties and values for the results object if you want to add more.